### PR TITLE
Fixbug 1.0 (Removing First Page Errors)

### DIFF
--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -98,11 +98,13 @@ export default {
           backgroundColor: '#F3F5FF',
         },
       },
-      selected: {
-        backgroundColor: '#F3F5FF !important',
-        '&:focus': {
-          backgroundColor: '#F3F5FF',
-        },
+      root: {
+        '&$selected': {
+          backgroundColor: '#F3F5FF !important',
+          '&:focus': {
+            backgroundColor: '#F3F5FF',
+          },
+        }
       }
     },
     MuiTouchRipple: {

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -6,6 +6,7 @@ export default {
 
 export const overrides = {
   typography: {
+    useNextVariants: true,
     h1: {
       fontSize: '3rem',
     },


### PR DESCRIPTION
```
[Error] index.js:1446 Warning: Material-UI: you are using the deprecated typography variants that will be removed in the next major release.
Please read the migration guide under https://material-ui.com/style/typography#migration-to-typography-v2
[Reference-Url]  https://material-ui.com/style/typography/#migration-to-typography-v2
```
 

```
[Error]
Warning: Material-UI: the `MuiListItem` component increases the CSS specificity of the `selected` internal state.
You can not override it like this: 
{
  "button": {
    "&:hover, &:focus": {
      "backgroundColor": "#F3F5FF"
    }
  },
  "selected": {
    "backgroundColor": "#F3F5FF !important",
    "&:focus": {
      "backgroundColor": "#F3F5FF"
    }
  }
}

Instead, you need to use the $ruleName syntax:
{
  "&$selected": {
    "backgroundColor": "#F3F5FF !important",
    "&:focus": {
      "backgroundColor": "#F3F5FF"
    }
  }
}
https://material-ui.com/customization/overrides#internal-states

[Reference-Url] https://material-ui.com/customization/overrides/#use-rulename-to-reference-a-local-rule-within-the-same-style-sheet
```
### Error Screenshots
![Screenshot from 2019-05-11 16-06-32](https://user-images.githubusercontent.com/7056772/57570542-de5e2c80-7420-11e9-8ea6-3dcb1512ce5c.png)

### Screenshot After removing  bug
![Screenshot from 2019-05-11 19-07-40](https://user-images.githubusercontent.com/7056772/57570577-1cf3e700-7421-11e9-9a47-0bfc01ed475c.png)
